### PR TITLE
[Fix] Don't collapse beeper input by giving it a toggle value in boos…

### DIFF
--- a/ts/desktop/controlBar.ts
+++ b/ts/desktop/controlBar.ts
@@ -43,7 +43,6 @@ export class ControlBar  {
         AppVars.registerDelayChangeListener((amount)=>this.ui.delayInput.val(amount));
 
         this.ConnectExecutionButtonGroup();
-        this.DeactivateInfiniteBeepers();
 
     }
     private ConnectExecutionButtonGroup() {

--- a/ts/desktop/controlBar.ts
+++ b/ts/desktop/controlBar.ts
@@ -43,6 +43,7 @@ export class ControlBar  {
         AppVars.registerDelayChangeListener((amount)=>this.ui.delayInput.val(amount));
 
         this.ConnectExecutionButtonGroup();
+        this.DeactivateInfiniteBeepers();
 
     }
     private ConnectExecutionButtonGroup() {
@@ -152,14 +153,14 @@ export class ControlBar  {
     }
 
     private ActivateInfiniteBeepers() {
-        bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0]).hide();
+        bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0], {toggle:true}).hide();
         this.ui.infiniteBeeperInput.removeClass("btn-body");
         this.ui.infiniteBeeperInput.addClass("btn-info");
     }
 
     
     private DeactivateInfiniteBeepers() {
-        bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0]).show();
+        bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0], {toggle:false}).show();
         this.ui.infiniteBeeperInput.removeClass("btn-info");
         this.ui.infiniteBeeperInput.addClass("btn-body");
     }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -459,7 +459,7 @@
                     <small class="d-none d-md-inline"><label for="beeperBag"> Mochila</label></small>                    
                     <i class="bi bi-backpack-fill d-block d-md-none"></i>
                 </div>
-                <div class="collapse collapse-horizontal show" id="beeperInputCollapse">
+                <div class="collapse collapse-horizontal show" id="beeperInputCollapse" data-bs-config="{toggle:false}">
                     <input type="number" id="beeperBag" class="form-control border-secondary rounded-0"
                         aria-label="" min="0" value="0">
                 </div>

--- a/webapp/js/cindex.js
+++ b/webapp/js/cindex.js
@@ -28008,6 +28008,7 @@ var karel = (function (exports, bootstrap) {
             });
             AppVars.registerDelayChangeListener((amount) => this.ui.delayInput.val(amount));
             this.ConnectExecutionButtonGroup();
+            this.DeactivateInfiniteBeepers();
         }
         ConnectExecutionButtonGroup() {
             const exec = this.ui.execution;
@@ -28106,12 +28107,12 @@ var karel = (function (exports, bootstrap) {
             }
         }
         ActivateInfiniteBeepers() {
-            bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0]).hide();
+            bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0], { toggle: true }).hide();
             this.ui.infiniteBeeperInput.removeClass("btn-body");
             this.ui.infiniteBeeperInput.addClass("btn-info");
         }
         DeactivateInfiniteBeepers() {
-            bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0]).show();
+            bootstrap.Collapse.getOrCreateInstance(this.ui.beeperCollapse[0], { toggle: false }).show();
             this.ui.infiniteBeeperInput.removeClass("btn-info");
             this.ui.infiniteBeeperInput.addClass("btn-body");
         }

--- a/webapp/js/cindex.js
+++ b/webapp/js/cindex.js
@@ -28008,7 +28008,6 @@ var karel = (function (exports, bootstrap) {
             });
             AppVars.registerDelayChangeListener((amount) => this.ui.delayInput.val(amount));
             this.ConnectExecutionButtonGroup();
-            this.DeactivateInfiniteBeepers();
         }
         ConnectExecutionButtonGroup() {
             const exec = this.ui.execution;


### PR DESCRIPTION
Fixes https://github.com/kishtarn555/ReKarel/issues/64

There was an issue where the collapsable was toggled when created the instance, fixed by giving it the correct desired toggle value